### PR TITLE
Mjs/resist uglify rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nuvi-daterange-picker",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuvi-daterange-picker",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A React based date range picker forked",
   "author": "Nuvi <developers@nuvi.com> (http://www.nuvi.com)",
   "license": "ISC",

--- a/src/DateRangePicker.js
+++ b/src/DateRangePicker.js
@@ -27,6 +27,8 @@ const absoluteMaximum = moment(new Date(8640000000000000 / 2)).startOf('day');
 function noop() {}
 
 class DateRangePicker extends BemMixin {
+  static displayName = 'DateRangePicker';
+
   static propTypes = {
     bemBlock: PropTypes.string,
     bemNamespace: PropTypes.string,

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import BemMixin from './utils/BemMixin';
 
 class Legend extends BemMixin {
+  static displayName = 'Legend';
+
   static propTypes = {
     selectedLabel: PropTypes.string.isRequired,
     stateDefinitions: PropTypes.object.isRequired,

--- a/src/PaginationArrow.js
+++ b/src/PaginationArrow.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import BemMixin from './utils/BemMixin';
 
 class PaginationArrow extends BemMixin {
+  static displayName = 'PaginationArrow';
+
   static propTypes = {
     disabled: PropTypes.bool,
     onTrigger: PropTypes.func,

--- a/src/calendar/CalendarDate.js
+++ b/src/calendar/CalendarDate.js
@@ -13,6 +13,8 @@ import CalendarSelection from './CalendarSelection';
 
 
 class CalendarDate extends BemMixin {
+  static displayName = 'CalendarDate';
+
   static propTypes = {
     date: CustomPropTypes.moment,
 

--- a/src/calendar/CalendarDatePeriod.js
+++ b/src/calendar/CalendarDatePeriod.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import BemMixin from '../utils/BemMixin';
 
 class CalendarDatePeriod extends BemMixin {
+  static displayName = 'CalendarDatePeriod';
+
   static propTypes = {
     color: PropTypes.string,
     period: PropTypes.string,

--- a/src/calendar/CalendarHighlight.js
+++ b/src/calendar/CalendarHighlight.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import BemMixin from '../utils/BemMixin';
 
 class CalendarHighlight extends BemMixin {
+  static displayName = 'CalendarHighlight';
+
   static propTypes = {
     modifier: PropTypes.string,
   };

--- a/src/calendar/CalendarMonth.js
+++ b/src/calendar/CalendarMonth.js
@@ -13,6 +13,8 @@ import isMomentRange from '../utils/isMomentRange';
 const moment = extendMoment(Moment);
 
 class CalendarMonth extends BemMixin {
+  static displayName = 'CalendarMonth';
+
   static propTypes = {
     dateComponent: PropTypes.func,
     disableNavigation: PropTypes.bool,

--- a/src/calendar/CalendarSelection.js
+++ b/src/calendar/CalendarSelection.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import BemMixin from '../utils/BemMixin';
 
 class CalendarSelection extends BemMixin {
+  static displayName = 'CalendarSelection';
+
   static propTypes = {
     modifier: PropTypes.string,
     pending: PropTypes.bool.isRequired,

--- a/src/utils/BemMixin.js
+++ b/src/utils/BemMixin.js
@@ -48,7 +48,7 @@ class BemMixin extends React.Component {
   cx(options = {}) {
     let opts = {
       namespace: this.getBemNamespace(),
-      element: this.constructor.name,
+      element: this.constructor.displayName,
       block: this.getBemBlock(),
     };
 


### PR DESCRIPTION
Since components get renamed during uglification, `this.constructor.name` is no longer suitable for use in BEM-style `className`s. So we provide a string alternative that is safely out of UglifyJS's reach.